### PR TITLE
Removes InstanceMethods module.

### DIFF
--- a/lib/active_layer/active_record/persistence.rb
+++ b/lib/active_layer/active_record/persistence.rb
@@ -9,15 +9,11 @@ module ActiveLayer
 
     module Persistence
       extend ActiveSupport::Concern
-      
-      module InstanceMethods
 
-        def save!
-          unless save
-            raise RecordInvalid.new(self)
-          end
+      def save!
+        unless save
+          raise RecordInvalid.new(self)
         end
-
       end
     end
   end

--- a/lib/active_layer/attributes.rb
+++ b/lib/active_layer/attributes.rb
@@ -29,30 +29,25 @@ module ActiveLayer
       end
       
     end
-    
-    module InstanceMethods
 
-      def attributes=(new_attributes)
-        return if new_attributes.nil?
-        attributes = new_attributes.stringify_keys
+    def attributes=(new_attributes)
+      return if new_attributes.nil?
+      attributes = new_attributes.stringify_keys
 
-        safe_attributes = if accessible_attributes.nil? 
-          attributes
-        else
-          attributes.reject { |key, value| !accessible_attributes.include?(key.gsub(/\(.+/, "")) }
-        end
-        
-        safe_attributes.each do |k, v|
-          respond_to?(:"#{k}=") ? send(:"#{k}=", v) : raise(UnknownAttributeError, "unknown attribute: #{k}")
-        end
+      safe_attributes = if accessible_attributes.nil?
+        attributes
+      else
+        attributes.reject { |key, value| !accessible_attributes.include?(key.gsub(/\(.+/, "")) }
       end
-      
-      # override persistence saving to pull in the guard functionality
-      def active_layer_attributes_setting(new_attributes)
-        self.attributes = new_attributes
+
+      safe_attributes.each do |k, v|
+        respond_to?(:"#{k}=") ? send(:"#{k}=", v) : raise(UnknownAttributeError, "unknown attribute: #{k}")
       end
-      
-      
-    end # InstanceMethods
+    end
+
+    # override persistence saving to pull in the guard functionality
+    def active_layer_attributes_setting(new_attributes)
+      self.attributes = new_attributes
+    end
   end # Attributes
 end # ActiveLayer

--- a/lib/active_layer/persistence.rb
+++ b/lib/active_layer/persistence.rb
@@ -17,44 +17,41 @@ module ActiveLayer
   module Persistence
     extend ActiveSupport::Concern
     include ActiveLayer::Proxy
-    
-    module InstanceMethods
-      def save
-        valid = self.respond_to?(:valid?, false) ? valid? : true
 
-        if valid
-          active_layer_save
-        else
-          false
-        end
-      end
-      
-      def save!
-        unless save
-          raise RecordInvalid.new(self)
-        end
-      end
-      
-      def update_attributes(new_attributes)
-        active_layer_attributes_setting(new_attributes)
-        save
-      end
+    def save
+      valid = self.respond_to?(:valid?, false) ? valid? : true
 
-      def update_attributes!(new_attributes)
-        active_layer_attributes_setting(new_attributes)
-        save!
+      if valid
+        active_layer_save
+      else
+        false
       end
+    end
 
-      # hook method to override saving behaviour
-      def active_layer_save
-        active_layer_object.save
+    def save!
+      unless save
+        raise RecordInvalid.new(self)
       end
-      
-      # another hook method to control attributes=
-      def active_layer_attributes_setting(new_attributes)
-        active_layer_object.attributes = new_attributes
-      end
-      
+    end
+
+    def update_attributes(new_attributes)
+      active_layer_attributes_setting(new_attributes)
+      save
+    end
+
+    def update_attributes!(new_attributes)
+      active_layer_attributes_setting(new_attributes)
+      save!
+    end
+
+    # hook method to override saving behaviour
+    def active_layer_save
+      active_layer_object.save
+    end
+
+    # another hook method to control attributes=
+    def active_layer_attributes_setting(new_attributes)
+      active_layer_object.attributes = new_attributes
     end
   end
 

--- a/lib/active_layer/proxy.rb
+++ b/lib/active_layer/proxy.rb
@@ -20,41 +20,36 @@ module ActiveLayer
         end
       end
     end
-    
-    module InstanceMethods
-      def initialize(*args, &block)
-        self.active_layer_object = args.first
-        super()
-      end  
-      
-      def active_layer_object
-        raise "active_layer_object was not set" if @active_layer_object.nil?
-        @active_layer_object
-      end
-      
-      def method_missing(method, *args, &block)
-        # puts "passing: #{method} + #{args.inspect} to #{active_layer_object.inspect}"
-        unless @active_layer_object.nil?
-          active_layer_object.send(method, *args, &block)
-        else
-          super
-        end
-      end
-      
-      def read_attribute_for_validation(key)
-        if active_layer_object.respond_to?(:read_attribute_for_validation)
-          active_layer_object.read_attribute_for_validation(key)
-        else
-          active_layer_object.send(key)
-        end
-      end
-    
-      def respond_to?(method, use_proxy = true)
-        super(method) || ( use_proxy && @active_layer_object && @active_layer_object.respond_to?(method) )
-      end
-      
-      
+
+    def initialize(*args, &block)
+      self.active_layer_object = args.first
+      super()
     end
-    
+
+    def active_layer_object
+      raise "active_layer_object was not set" if @active_layer_object.nil?
+      @active_layer_object
+    end
+
+    def method_missing(method, *args, &block)
+      # puts "passing: #{method} + #{args.inspect} to #{active_layer_object.inspect}"
+      unless @active_layer_object.nil?
+        active_layer_object.send(method, *args, &block)
+      else
+        super
+      end
+    end
+
+    def read_attribute_for_validation(key)
+      if active_layer_object.respond_to?(:read_attribute_for_validation)
+        active_layer_object.read_attribute_for_validation(key)
+      else
+        active_layer_object.send(key)
+      end
+    end
+
+    def respond_to?(method, use_proxy = true)
+      super(method) || ( use_proxy && @active_layer_object && @active_layer_object.respond_to?(method) )
+    end
   end
 end

--- a/lib/active_layer/validations.rb
+++ b/lib/active_layer/validations.rb
@@ -41,15 +41,15 @@ module ActiveLayer
 
     # Private: Adds the passed in errors to the validator instance errors
     #
-    # errors_to_merge_in - a hash of errors eg {:name => 'must be present'}
+    # errors_to_merge_in - a hash of errors eg {:name => ['must be present']}
     # prefix - optional string to prepend to error attribute's name
     #
     # Return value not used
 
     def merge_errors(errors_to_merge_in, prefix = nil)
-      errors_to_merge_in.each do |child_attribute, message|
+      errors_to_merge_in.each do |child_attribute, messages|
         attribute = "#{prefix}#{child_attribute}"
-        errors[attribute] << message unless message.nil? || message.empty?
+        errors[attribute].concat(Array(messages))
         errors[attribute].uniq!
       end
     end

--- a/lib/active_layer/validations.rb
+++ b/lib/active_layer/validations.rb
@@ -49,7 +49,7 @@ module ActiveLayer
     def merge_errors(errors_to_merge_in, prefix = nil)
       errors_to_merge_in.each do |child_attribute, message|
         attribute = "#{prefix}#{child_attribute}"
-        errors[attribute] << message
+        errors[attribute] << message unless message.nil? || message.empty?
         errors[attribute].uniq!
       end
     end

--- a/lib/active_layer/validations.rb
+++ b/lib/active_layer/validations.rb
@@ -14,57 +14,53 @@ module ActiveLayer
       define_model_callbacks :validation
     end
 
-    module InstanceMethods
      
-      # model validation methods
-      def errors
-        if active_layer_object.respond_to?(:errors)
-          active_layer_object.errors
-        else
-          super
-        end
+    # model validation methods
+    def errors
+      if active_layer_object.respond_to?(:errors)
+        active_layer_object.errors
+      else
+        super
       end
-
-      # Private: Preserves errors before a passed in block is executed.
-      #          Then merges the preserved errors into the validator instance 
-      #          errors hash after the block is executed. 
-      #
-      # prefix - optional string to prepend to error attribute's name
-      # 
-      # Returns the value of the evaluated block
-
-      def keep_errors(prefix = "")
-        original_errors = errors.respond_to?(:messages) ? errors.messages.dup : errors.dup
-        result = yield
-        merge_errors(original_errors, prefix)
-        result
-      end
-
-      # Private: Adds the passed in errors to the validator instance errors
-      #
-      # errors_to_merge_in - a hash of errors eg {:name => 'must be present'}
-      # prefix - optional string to prepend to error attribute's name
-      #
-      # Return value not used
-
-      def merge_errors(errors_to_merge_in, prefix = nil)
-        errors_to_merge_in.each do |child_attribute, message|
-          attribute = "#{prefix}#{child_attribute}"
-          errors[attribute] << message
-          errors[attribute].uniq!
-        end
-      end
-
-      def valid?(*)
-        _run_validation_callbacks do
-          result = nil
-          keep_errors { active_layer_object.valid? } if active_layer_object.respond_to?(:valid?) && !_validator
-          keep_errors { result = super }
-          errors.empty? && result
-        end
-      end
-    
     end
 
+    # Private: Preserves errors before a passed in block is executed.
+    #          Then merges the preserved errors into the validator instance
+    #          errors hash after the block is executed.
+    #
+    # prefix - optional string to prepend to error attribute's name
+    #
+    # Returns the value of the evaluated block
+
+    def keep_errors(prefix = "")
+      original_errors = errors.respond_to?(:messages) ? errors.messages.dup : errors.dup
+      result = yield
+      merge_errors(original_errors, prefix)
+      result
+    end
+
+    # Private: Adds the passed in errors to the validator instance errors
+    #
+    # errors_to_merge_in - a hash of errors eg {:name => 'must be present'}
+    # prefix - optional string to prepend to error attribute's name
+    #
+    # Return value not used
+
+    def merge_errors(errors_to_merge_in, prefix = nil)
+      errors_to_merge_in.each do |child_attribute, message|
+        attribute = "#{prefix}#{child_attribute}"
+        errors[attribute] << message
+        errors[attribute].uniq!
+      end
+    end
+
+    def valid?(*)
+      _run_validation_callbacks do
+        result = nil
+        keep_errors { active_layer_object.valid? } if active_layer_object.respond_to?(:valid?) && !_validator
+        keep_errors { result = super }
+        errors.empty? && result
+      end
+    end
   end  # Validations
 end # ActiveLayer

--- a/lib/active_layer/validations/validator.rb
+++ b/lib/active_layer/validations/validator.rb
@@ -8,56 +8,49 @@ module ActiveLayer
       included do
         attr_accessor :_validator
       end
-      
-      module InstanceMethods
 
-        def initialize(*args, &block)
-          if args.first.is_a?(Hash)
-            options = args.first
-            if options.has_key?(:attributes)
-              self._validator = EachValidator.new(options)
-            else
-              self._validator = ObjectValidator.new(options)
-            end
-            _validator.active_layer_validator = self
-          end
-          super 
-        end
-
-        # adapter methods
-        def setup(record)
-          # nothing to do...
-        end
-
-        # adapter methods
-        def attributes
-          _validator && _validator.respond_to?(:attributes) ? _validator.attributes : []
-        end
-
-        def errors
-          if _validator
-            @errors ||= ActiveModel::Errors.new(self)
+      def initialize(*args, &block)
+        if args.first.is_a?(Hash)
+          options = args.first
+          if options.has_key?(:attributes)
+            self._validator = EachValidator.new(options)
           else
-            super
+            self._validator = ObjectValidator.new(options)
           end
+          _validator.active_layer_validator = self
         end
-        
-        # This method is called in two contexts, as part of the validation callbacks when it's setup
-        # as an adapter and to register a standard callback
-        #
-        def validate(*args, &block)
-          # puts "calling validate on #{self.class.name}"
-          if _validator
-            _validator.validate(*args, &block)
-          else
-            super
-          end
-        end
-        
+        super
       end
-      
-      
-      
+
+      # adapter methods
+      def setup(record)
+        # nothing to do...
+      end
+
+      # adapter methods
+      def attributes
+        _validator && _validator.respond_to?(:attributes) ? _validator.attributes : []
+      end
+
+      def errors
+        if _validator
+          @errors ||= ActiveModel::Errors.new(self)
+        else
+          super
+        end
+      end
+
+      # This method is called in two contexts, as part of the validation callbacks when it's setup
+      # as an adapter and to register a standard callback
+      #
+      def validate(*args, &block)
+        # puts "calling validate on #{self.class.name}"
+        if _validator
+          _validator.validate(*args, &block)
+        else
+          super
+        end
+      end
     end
   end
 end

--- a/lib/active_layer/version.rb
+++ b/lib/active_layer/version.rb
@@ -1,3 +1,3 @@
 module ActiveLayer
-  VERSION = "0.0.10"
+  VERSION = "0.0.11"
 end


### PR DESCRIPTION
Removes InstanceMethods module everywhere to fix deprecation warning.
The InstanceMethods module inside ActiveSupport::Concern will be no longer included automatically.
